### PR TITLE
Autoyes when attempting creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default: test
+
+test: test_default test_force_create
+
+test_default:
+	vagrant destroy -f
+	PLAYBOOK_FILE='test_default.yml' vagrant up
+
+test_force_create:
+	vagrant destroy -f
+	PLAYBOOK_FILE='test_force_create.yml' vagrant up

--- a/README.md
+++ b/README.md
@@ -26,3 +26,11 @@ software_raid_devices:
     - /dev/sde
 ```
 
+## Testing
+
+Test against vagrant. Add a yml file and environment variable in the 
+make file to tell the Vagrantfile what yml config to run.
+
+```
+make test
+```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ## Variables
 ```yaml
 software_raid_alerts_email: "email@example.com"
+software_raid_create_kwargs: "--run" # force the creation if there are any prompts
 software_raid_devices:
 - device: /dev/md0
   level: 0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ software_raid_devices:
   filesystem_type: "ext4"
   mount_point: "/mnt/volume"
   mount_options: "noatime,noexec,nodiratime"
-  passno: "0 0"
+  dump: 0
+  passno: 0
 - device: /dev/md1
   level: 1
   components:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # information on available options.
     config.vm.provision "ansible" do |ansible|
-      ansible.playbook = "test.yml"
+      ansible.playbook = ENV['PLAYBOOK_FILE']
       ansible.verbose = 'vv'
       ansible.sudo = true
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.define host[:name] do |node|
       node.vm.hostname = host[:name]
-      node.vm.box = "ubuntu1404-amd64"
+      node.vm.box = "ubuntu/trusty64"
       node.vm.provider :virtualbox do |vb|
         vb.name = host[:name]
         vb.customize ["modifyvm", :id, "--cpuexecutioncap", host[:cpu_cap]]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 
 software_raid_alerts_email: "root"
+software_raid_force_create: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 
 software_raid_alerts_email: "root"
-software_raid_force_create: false
+software_raid_create_kwargs: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,23 +12,12 @@
     with_items: software_raid_devices
     when: software_raid_devices is defined
 
-  - name: software raid - create command to initialise raid devices
-    shell: echo "mdadm -v --create {{ item.0.device }} --level={{ item.0.level }} --raid-devices={{ item.0.components | length }} {{ item.0.components | join(" ") }}"
+  - name: software raid - initialise raid devices
+    shell: mdadm -v --create {{ item.0.device }} --level={{ item.0.level }} --raid-devices={{ item.0.components | length }} {{ item.0.components | join(" ") }} {{ software_raid_create_kwargs }}
     with_together:
       - software_raid_devices
       - mdadm_check.results
     when: software_raid_devices is defined and item.1.rc != 0
-    register: software_raid_mdadm_create
-
-  - name: software raid - force initialise raid devices
-    shell: yes | {{ item['stdout'] }}
-    with_items: software_raid_mdadm_create.results
-    when: software_raid_force_create and not software_raid_mdadm_create.results.0|skipped
-
-  - name: software raid - initialise raid devices
-    shell: "{{ item['stdout'] }}"
-    with_items: software_raid_mdadm_create.results
-    when: not software_raid_force_create and not software_raid_mdadm_create.results.0|skipped
 
   - name: software raid - scan raid devices
     shell: "mdadm --detail --scan"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,12 +12,23 @@
     with_items: software_raid_devices
     when: software_raid_devices is defined
 
-  - name: software raid - initialise raid devices
-    shell: mdadm -v --create {{ item.0.device }} --level={{ item.0.level }} --raid-devices={{ item.0.components | length }} {{ item.0.components | join(" ") }}
+  - name: software raid - create command to initialise raid devices
+    shell: echo "mdadm -v --create {{ item.0.device }} --level={{ item.0.level }} --raid-devices={{ item.0.components | length }} {{ item.0.components | join(" ") }}"
     with_together:
       - software_raid_devices
       - mdadm_check.results
     when: software_raid_devices is defined and item.1.rc != 0
+    register: software_raid_mdadm_create
+
+  - name: software raid - force initialise raid devices
+    shell: yes | {{ item['stdout'] }}
+    with_items: software_raid_mdadm_create.results
+    when: software_raid_force_create and not software_raid_mdadm_create.results.0|skipped
+
+  - name: software raid - initialise raid devices
+    shell: "{{ item['stdout'] }}"
+    with_items: software_raid_mdadm_create.results
+    when: not software_raid_force_create and not software_raid_mdadm_create.results.0|skipped
 
   - name: software raid - scan raid devices
     shell: "mdadm --detail --scan"

--- a/test_default.yml
+++ b/test_default.yml
@@ -1,0 +1,19 @@
+---
+
+- hosts: all
+  roles:
+    - .
+
+  vars:
+    software_raid_alerts_email: "email@example.com"
+    software_raid_devices:
+      - device: /dev/md0
+        level: 0
+        components:
+          - /dev/sdb
+          - /dev/sdc
+        filesystem_type: "ext4"
+        mount_point: "/mnt/volume"
+        mount_options: "noatime,noexec,nodiratime"
+        dump: 0
+        passno: 0

--- a/test_force_create.yml
+++ b/test_force_create.yml
@@ -2,10 +2,11 @@
 
 - hosts: all
   roles:
-    - jacoelho.softwareraid
+    - .
 
   vars:
     software_raid_alerts_email: "email@example.com"
+    software_raid_force_create: true
     software_raid_devices:
       - device: /dev/md0
         level: 0

--- a/test_force_create.yml
+++ b/test_force_create.yml
@@ -6,7 +6,7 @@
 
   vars:
     software_raid_alerts_email: "email@example.com"
-    software_raid_force_create: true
+    software_raid_create_kwargs: "--run"
     software_raid_devices:
       - device: /dev/md0
         level: 0


### PR DESCRIPTION
Sometimes when creating a raid array it will ask if you are
sure about taking this action. Have the option to force or auto reply yes.

http://stackoverflow.com/questions/8707156/scripting-mdadm-when-a-component-device-may-contain-ext2-file-system-already

I also updated a few things. The commit messages should be fairly verbose, but let me know if you have any questions or concerns.
