### PR TITLE
Cleanup of deprecation warnings and spurious change notifications

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,14 +9,14 @@
     shell: "mdadm -D {{ item.device }}"
     ignore_errors: yes
     register: mdadm_check
-    with_items: software_raid_devices
+    with_items: "{{ software_raid_devices }}"
     when: software_raid_devices is defined
 
   - name: software raid - initialise raid devices
     shell: mdadm -v --create {{ item.0.device }} --level={{ item.0.level }} --raid-devices={{ item.0.components | length }} {{ item.0.components | join(" ") }} {{ software_raid_create_kwargs }}
     with_together:
-      - software_raid_devices
-      - mdadm_check.results
+      - "{{ software_raid_devices }}"
+      - "{{ mdadm_check.results }}"
     when: software_raid_devices is defined and item.1.rc != 0
 
   - name: software raid - scan raid devices
@@ -38,7 +38,7 @@
     filesystem:
       fstype: "{{ item.filesystem_type }}"
       dev: "{{ item.device }}"
-    with_items: software_raid_devices
+    with_items: "{{ software_raid_devices }}"
     when: software_raid_devices is defined and item.mount_point is defined
 
   - name: software raid - mount raid devices
@@ -50,5 +50,5 @@
       dump: "{{ item.dump }}"
       passno: "{{ item.passno }}"
       state: mounted
-    with_items: software_raid_devices
+    with_items: "{{ software_raid_devices }}"
     when: software_raid_devices is defined and item.mount_point is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
     register: mdadm_check
     with_items: "{{ software_raid_devices }}"
     when: software_raid_devices is defined
+    changed_when: false
 
   - name: software raid - initialise raid devices
     shell: mdadm -v --create {{ item.0.device }} --level={{ item.0.level }} --raid-devices={{ item.0.components | length }} {{ item.0.components | join(" ") }} {{ software_raid_create_kwargs }}
@@ -24,6 +25,7 @@
     ignore_errors: yes
     register: mdadm_scan
     when: software_raid_devices is defined
+    changed_when: false
 
   - name: software raid - create mdadm config file
     template: src=mdadm.conf.j2 dest=/etc/mdadm/mdadm.conf
@@ -33,6 +35,7 @@
     shell: "update-initramfs -u"
     ignore_errors: yes
     when: software_raid_devices is defined and ansible_os_family == "Debian"
+    changed_when: false
 
   - name: software raid - filesystem creation
     filesystem:

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -5,7 +5,7 @@
         - item.device != ""
         - item.level != ""
         - item.components | length > 1
-    with_items: software_raid_devices
+    with_items: "{{ software_raid_devices }}"
     when: software_raid_devices is defined
 
 
@@ -16,5 +16,5 @@
         - item.mount_options != ""
         - item.passno != ""
         - item.dump != ""
-    with_items: software_raid_devices
+    with_items: "{{ software_raid_devices }}"
     when: software_raid_devices is defined and item.mount_point is defined

--- a/templates/mdadm.conf.j2
+++ b/templates/mdadm.conf.j2
@@ -8,7 +8,7 @@ CREATE owner=root group=disk mode=0660 auto=yes
 HOMEHOST <system>
 
 # instruct the monitoring daemon where to send mail alerts
-MAILADDR {{ software_raid_alerts_email }}
+MAILADDR  {{ software_raid_alerts_email }}
 
 # definitions of existing MD arrays
 {{ mdadm_scan.stdout }}


### PR DESCRIPTION
These changes clean up some deprecation warnings around bare variables, as well as change notices for shell commands.
The mdadm.conf template has also been updated because Ansible would periodically find that mdadm.conf had been changed (I suspect by mdam or initramfs invoked via shell).
